### PR TITLE
Transpose simple method

### DIFF
--- a/src/chordparser/chords.py
+++ b/src/chordparser/chords.py
@@ -152,6 +152,17 @@ class Chord:
         self.build()
         return self
 
+    def transpose_simple(self, semitones: int, use_flats=False):
+        """Transpose a Chord by specifying the change in semitone intervals. Use use_flats=True to transpose using flat accidentals."""
+        prev = self.NE.create_note(self.root.value)
+        self.root.transpose_simple(semitones, use_flats)
+        if self.bass:
+            # bass has to be transposed exact!
+            (diff,) = self.NE.get_tone_letter(prev, self.root)
+            self.bass.transpose(*diff)
+        self.build()
+        return self
+
     def _xstr(self, value):
         # To print blank for None values
         if value is None:

--- a/src/chordparser/notes.py
+++ b/src/chordparser/notes.py
@@ -4,7 +4,7 @@ class Note:
 
     The Note class consists of notation a-g or A-G, with optional unicode accidental symbols \u266d, \u266f, \U0001D12B, or \U0001D12A. It is created by the NoteEditor.
 
-    Notes can have accidentals set using the 'accidental' method, and can be shifted by semitones using the 'shift_s' method. The letter of the Note can be shifted using the 'shift_l' method. Notes also have 'letter' and 'symbol' methods to get their respective values. Numerical representation of the Note value can be accessed via the 'num_value', 'letter_value' and 'symbol_value' methods. Notes can be transposed using the 'transpose' method.
+    Notes can have accidentals set using the 'accidental' method, and can be shifted by semitones using the 'shift_s' method. The letter of the Note can be shifted using the 'shift_l' method. Notes also have 'letter' and 'symbol' methods to get their respective values. Numerical representation of the Note value can be accessed via the 'num_value', 'letter_value' and 'symbol_value' methods. Notes can be transposed using the 'transpose' or 'transpose_simple' methods.
 
     Notes can be compared either with other Notes or with strings.
     """
@@ -33,7 +33,19 @@ class Note:
     }
     _notes_tuple = (
         'C', 'D', 'E', 'F', 'G', 'A', 'B',
-        'C', 'D', 'E', 'F', 'G', 'A', 'B')
+        'C', 'D', 'E', 'F', 'G', 'A', 'B',
+    )
+    _sharp_tuple = (
+        'C', 'C\u266f', 'D', 'D\u266f', 'E',
+        'F', 'F\u266f', 'G', 'G\u266f', 'A',
+        'A\u266f', 'B',
+    )
+    _flat_tuple = (
+        'C', 'D\u266d', 'D', 'E\u266d', 'E',
+        'F', 'G\u266d', 'G', 'A\u266d', 'A',
+        'B\u266d', 'B',
+    )
+
 
     def __init__(self, value):
         self.value = value
@@ -95,6 +107,16 @@ class Note:
         shift = (new_val - curr_val) % 12
         shift = shift - 12 if shift > 6 else shift  # shift downwards if closer
         self.shift_s(shift)
+        return self
+
+    def transpose_simple(self, semitones: int, use_flats=False):
+        """Transpose a note by specifying the change in semitone intervals. Use use_flats=True to transpose using flat accidentals."""
+        if use_flats:
+            note_list = Note._flat_tuple
+        else:
+            note_list = Note._sharp_tuple
+        new = note_list[(self.num_value() + semitones) % 12]
+        self.value = new
         return self
 
     def __repr__(self):

--- a/src/chordparser/scales.py
+++ b/src/chordparser/scales.py
@@ -59,6 +59,12 @@ class Scale:
         self.build()
         return self
 
+    def transpose_simple(self, semitones: int, use_flats=False):
+        """Transpose the key of the scale by specifying the change in semitone intervals. Use use_flats=True to transpose using flat accidentals."""
+        self.key.transpose_simple(semitones, use_flats)
+        self.build()
+        return self
+
     def __repr__(self):
         return f'{self.key} scale'
 

--- a/tests/test_chords.py
+++ b/tests/test_chords.py
@@ -94,6 +94,20 @@ def test_transpose(string, semitones, letter, notation):
     assert repr(new_chord) == notation
 
 
+def test_transpose_simple():
+    new_chord = CE.create_chord("C#/G")
+    new_chord.transpose_simple(1)
+    assert "D" == new_chord.root
+    assert "A\u266d" == new_chord.bass
+
+
+def test_transpose_simple_flats():
+    c = CE.create_chord("C/Gb")
+    c.transpose_simple(1, use_flats=True)
+    assert "D\u266d" == c.root
+    assert "A\U0001D12B" == c.bass
+
+
 @pytest.mark.parametrize(
     "input, output", [
         ("hey", "hey"), (None, '')

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -131,3 +131,27 @@ def test_note_transpose(note, semitone, letter, new_note):
     nnote = NE.create_note(note)
     nnote.transpose(semitone, letter)
     assert nnote == new_note
+
+
+def test_transpose_simple():
+    n = NE.create_note("C")
+    n.transpose_simple(2)
+    assert "D" == n
+
+
+def test_transpose_simple_2():
+    n = NE.create_note("C")
+    n.transpose_simple(-13)
+    assert "B" == n
+
+
+def test_transpose_simple_sharps():
+    n = NE.create_note("C")
+    n.transpose_simple(3)
+    assert "D\u266f" == n
+
+
+def test_transpose_simple_flats():
+    n = NE.create_note("C")
+    n.transpose_simple(3, use_flats=True)
+    assert "E\u266d" == n

--- a/tests/test_scales.py
+++ b/tests/test_scales.py
@@ -70,11 +70,25 @@ def test_scale_submode_notes(key, mode, submode, note):
     assert scale.notes == note
 
 
-def test_scale_transpose_sharps():
+def test_scale_transpose():
     nkey = KE.create_key("D")
     new_scale = SE.create_scale("C")
     new_scale.transpose(2, 1)
     assert new_scale.key == nkey
+
+
+def test_scale_transpose_simple():
+    s = SE.create_scale("C")
+    s.transpose_simple(1)
+    assert "C\u266f" == s.notes[0]
+    assert "C\u266f" == s.key.root
+
+
+def test_scale_transpose_simple_flats():
+    s = SE.create_scale("C")
+    s.transpose_simple(1, use_flats=True)
+    assert "D\u266d" == s.notes[0]
+    assert "D\u266d" == s.key.root
 
 
 def test_scale_repr():


### PR DESCRIPTION
Current transpose method requires knowing both the semitone and letter shift to get an accurate transposition. `transpose_simple` gives a quick and dirty fix to transposition by just specifying the number of semitones. The use of sharps and flats is controlled by the use_flats boolean keyword argument (default False). The method has been added to Notes, Scales and Chords (Keys have Notes' attributes). 