### PR TITLE
Include __str__

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,9 +39,9 @@ Contents
 .. licence
 .. history
 
-
+------------------
 Indices and tables
-==================
+------------------
 
 * :ref:`genindex`
 * :ref:`modindex`

--- a/src/chordparser/music/chords.py
+++ b/src/chordparser/music/chords.py
@@ -167,6 +167,9 @@ class Chord:
     def __repr__(self):
         return f'{self.notation} chord'
 
+    def __str__(self):
+        return self.notation
+
     def __eq__(self, other):
         # Allow comparison between Chords by checking their basic attributes
         if not isinstance(other, Chord):

--- a/src/chordparser/music/notes.py
+++ b/src/chordparser/music/notes.py
@@ -115,6 +115,9 @@ class Note:
         return self
 
     def __repr__(self):
+        return self.value + " note"
+
+    def __str__(self):
         return self.value
 
     def __eq__(self, other):

--- a/src/chordparser/music/quality.py
+++ b/src/chordparser/music/quality.py
@@ -172,6 +172,9 @@ class Quality:
         split_string.insert(-1, "flat")
         return " ".join(split_string)
 
+    def __str__(self):
+        return self.short()
+
     def __eq__(self, other):
         if not isinstance(other, Quality):
             return NotImplemented

--- a/src/chordparser/music/roman.py
+++ b/src/chordparser/music/roman.py
@@ -10,6 +10,9 @@ class Roman:
         self.notation = self.root + self.quality + inv_str
 
     def __repr__(self):
+        return self.notation + " roman chord"
+
+    def __str__(self):
         return self.notation
 
     def __eq__(self, other):

--- a/src/chordparser/music/scales.py
+++ b/src/chordparser/music/scales.py
@@ -72,6 +72,9 @@ class Scale:
     def __repr__(self):
         return f'{self.key} scale'
 
+    def __str__(self):
+        return str(self.key)
+
     def __eq__(self, other):
         # Allow comparison between Keys by checking their basic attributes
         if not isinstance(other, Scale):

--- a/tests/test_editors/test_chords_editor.py
+++ b/tests/test_editors/test_chords_editor.py
@@ -31,12 +31,12 @@ def test_chord_root(value):
 
 def test_quality():
     c = CE._parse_quality("minmaj7")
-    assert "minor major seventh" == str(c)
+    assert "minor major seventh" == repr(c)
 
 
 def test_quality_capital():
     c = CE.create_chord("c7")
-    assert "minor seventh" == str(c.quality)
+    assert "minor seventh" == repr(c.quality)
 
 
 @pytest.mark.parametrize(
@@ -77,7 +77,7 @@ def test_bass_2():
 def test_create_chord_everything():
     c = CE.create_chord("C#dim7addb4/E")
     assert "C\u266f" == c.root
-    assert "diminished seventh" == str(c.quality)
+    assert "diminished seventh" == repr(c.quality)
     assert [("\u266d", 4)] == c.add
     assert "E" == c.bass
 
@@ -92,7 +92,7 @@ def test_create_chord_everything():
 def test_diatonic(degree, quality):
     s = SE.create_scale('C', 'major')
     c = CE.create_diatonic(s, degree)
-    assert str(c.quality) == quality
+    assert repr(c.quality) == quality
 
 
 @pytest.mark.parametrize(
@@ -105,7 +105,7 @@ def test_diatonic(degree, quality):
 def test_diatonic_2(degree, quality):
     s = KE.create_key('C', 'major')
     c = CE.create_diatonic(s, degree)
-    assert str(c.quality) == quality
+    assert repr(c.quality) == quality
 
 
 @pytest.mark.parametrize("degree", [0, len])

--- a/tests/test_music/test_chords.py
+++ b/tests/test_music/test_chords.py
@@ -71,20 +71,6 @@ def test_bass_notes(name, notes, sym, deg, intervals, inversion):
 
 
 @pytest.mark.parametrize(
-    "string, notation", [
-        ("Cmajsus2add9/G", "Csus2add9/G chord"),
-        ("Cmaj9sus4add#9#13/G#", "Cmaj9sus\u266F9\u266F13/G\u266F chord"),
-        ("Caugmaj11", "Cmaj11\u266F5 chord"),
-        ("Cadd2", "Cadd2 chord"),
-        ("Cadd2addb6", "Cadd2\u266d6 chord"),
-        ]
-    )
-def test_notation(string, notation):
-    c = CE.create_chord(string)
-    assert repr(c) == notation
-
-
-@pytest.mark.parametrize(
     "string, semitones, letter, notation", [
         ('C', 3, 1, 'D\u266f chord'),
         ('Dm7add4/A', -5, -3, 'Am7add4/E chord'),
@@ -107,6 +93,25 @@ def test_transpose_simple_flats():
     c.transpose_simple(1, use_flats=True)
     assert "D\u266d" == c.root
     assert "A\U0001D12B" == c.bass
+
+
+@pytest.mark.parametrize(
+    "string, notation", [
+        ("Cmajsus2add9/G", "Csus2add9/G chord"),
+        ("Cmaj9sus4add#9#13/G#", "Cmaj9sus\u266F9\u266F13/G\u266F chord"),
+        ("Caugmaj11", "Cmaj11\u266F5 chord"),
+        ("Cadd2", "Cadd2 chord"),
+        ("Cadd2addb6", "Cadd2\u266d6 chord"),
+        ]
+    )
+def test_notation(string, notation):
+    c = CE.create_chord(string)
+    assert repr(c) == notation
+
+
+def test_str():
+    c = CE.create_chord("Cmajsus2add9/G")
+    assert "Csus2add9/G" == str(c)
 
 
 def test_chord_equality():

--- a/tests/test_music/test_notes.py
+++ b/tests/test_music/test_notes.py
@@ -143,7 +143,14 @@ def test_transpose_simple_flats():
     "note", ['C', 'D\u266F', 'G\u266D', 'A\U0001D12B', 'B\U0001D12A'])
 def test_note_creation_repr(note):
     new_note = NE.create_note(note)
-    assert repr(new_note) == note
+    assert repr(new_note) == note + " note"
+
+
+@pytest.mark.parametrize(
+    "note", ['C', 'D\u266F', 'G\u266D', 'A\U0001D12B', 'B\U0001D12A'])
+def test_note_creation_str(note):
+    new_note = NE.create_note(note)
+    assert str(new_note) == note
 
 
 @pytest.mark.parametrize(

--- a/tests/test_music/test_quality.py
+++ b/tests/test_music/test_quality.py
@@ -93,40 +93,6 @@ def test_sym_base(quality, ext, sym):
     assert sym == q.base_symbols
 
 
-@pytest.mark.parametrize(
-    "quality, name", [
-        ("major", "major"),
-        ("sus2", "sus2"),
-    ]
-)
-def test_long_repr(quality, name):
-    q = Quality(quality)
-    assert name == str(q)
-
-
-@pytest.mark.parametrize(
-    "quality, ext, name", [
-        ("dominant", "ninth", "dominant ninth"),
-        ("major", "major seventh", "major seventh"),
-        ("diminished", "diminished seventh", "diminished seventh"),
-    ]
-)
-def test_long_repr_with_ext(quality, ext, name):
-    q = Quality(quality, ext)
-    assert name == str(q)
-
-
-@pytest.mark.parametrize(
-    "quality, ext, name", [
-        ("dominant", "ninth", "dominant flat ninth"),
-        ("major", "major eleventh", "major flat eleventh"),
-    ]
-)
-def test_long_repr_with_flat_ext(quality, ext, name):
-    q = Quality(quality, ext, True)
-    assert name == str(q)
-
-
 def test_short():
     q = Quality("diminished")
     assert "dim" == q.short()
@@ -145,6 +111,45 @@ def test_short_halfdim():
 def test_short_sus():
     q = Quality("sus4", "seventh")
     assert "7sus" == q.short()
+
+
+@pytest.mark.parametrize(
+    "quality, name", [
+        ("major", "major"),
+        ("sus2", "sus2"),
+    ]
+)
+def test_long_repr(quality, name):
+    q = Quality(quality)
+    assert name == repr(q)
+
+
+@pytest.mark.parametrize(
+    "quality, ext, name", [
+        ("dominant", "ninth", "dominant ninth"),
+        ("major", "major seventh", "major seventh"),
+        ("diminished", "diminished seventh", "diminished seventh"),
+    ]
+)
+def test_long_repr_with_ext(quality, ext, name):
+    q = Quality(quality, ext)
+    assert name == repr(q)
+
+
+@pytest.mark.parametrize(
+    "quality, ext, name", [
+        ("dominant", "ninth", "dominant flat ninth"),
+        ("major", "major eleventh", "major flat eleventh"),
+    ]
+)
+def test_long_repr_with_flat_ext(quality, ext, name):
+    q = Quality(quality, ext, True)
+    assert name == repr(q)
+
+
+def test_str():
+    q = Quality("major", "major seventh")
+    assert "maj7" == str(q)
 
 
 def test_equality_not_implemented():

--- a/tests/test_music/test_roman.py
+++ b/tests/test_music/test_roman.py
@@ -18,6 +18,11 @@ def test_notation_3():
     assert "IV+6" == str(r)
 
 
+def test_repr():
+    r = Roman("IV", "+", (6,))
+    assert "IV+6 roman chord" == repr(r)
+
+
 def test_equality():
     r = Roman("I", "+", (6,))
     o = Roman("I", "+", (6,))

--- a/tests/test_music/test_scales.py
+++ b/tests/test_music/test_scales.py
@@ -88,6 +88,11 @@ def test_scale_repr():
     assert repr(new_scale) == "C harmonic minor scale"
 
 
+def test_scale_str():
+    new_scale = SE.create_scale('C', 'minor', 'harmonic')
+    assert str(new_scale) == "C harmonic minor"
+
+
 def test_scale_equality():
     s = SE.create_scale('C', 'dorian')
     assert s == SE.create_scale('C', 'dorian')


### PR DESCRIPTION
Current __repr__ function has a formal representation of musical classes but it is not fit for notation on chord sheets. Included __str__ for musical classes so they print nicely.