### PR TITLE
Update docs to new imports

### DIFF
--- a/docs/reference/parser.rst
+++ b/docs/reference/parser.rst
@@ -1,5 +1,5 @@
-Parser
-======
+Parser (All-in-One Editor and Analyser)
+=======================================
 
 .. autoclass:: chordparser.Parser
     :members:

--- a/src/chordparser/analysers/chords_analyser.py
+++ b/src/chordparser/analysers/chords_analyser.py
@@ -1,4 +1,3 @@
-from typing import List
 import warnings
 
 from chordparser.editors.chord_roman_converter import ChordRomanConverter
@@ -28,10 +27,10 @@ class ChordAnalyser:
 
     def analyse_diatonic(
             self, chord, scale,
-            incl_submodes: bool = False,
+            incl_submodes=False,
             allow_power_sus=False,
             default_power_sus="M",
-    ) -> List[tuple]:
+    ):
         """Analyse if a `Chord` is diatonic to a `Scale`.
 
         There may be multiple tuples in the returned list if submodes are included.
@@ -115,7 +114,7 @@ class ChordAnalyser:
 
     def analyse_all(
             self, chord, scale,
-            incl_submodes: bool = False,
+            incl_submodes=False,
             allow_power_sus=False,
             default_power_sus="M",
     ):
@@ -185,8 +184,8 @@ class ChordAnalyser:
         return chords
 
     def analyse_secondary(
-            self, prev_chord, next_chord, scale,
-            incl_submodes: bool = False,
+            self, prev_chord, next_chord,
+            scale, incl_submodes=False,
             allow_power_sus=False,
             default_power_sus="M",
             limit=True,

--- a/src/chordparser/editors/chords_editor.py
+++ b/src/chordparser/editors/chords_editor.py
@@ -1,5 +1,4 @@
 import re
-from typing import Union
 
 from chordparser.editors.notes_editor import NoteEditor
 from chordparser.editors.quality_editor import QualityEditor
@@ -116,7 +115,7 @@ class ChordEditor:
             return None
         return self._NE.create_note(string)
 
-    def create_diatonic(self, scale_key: Union[Scale, Key], degree: int = 1):
+    def create_diatonic(self, scale_key, degree=1):
         """Create a diatonic `Chord` from a `Scale` or `Key`.
 
         Parameters
@@ -175,13 +174,9 @@ class ChordEditor:
         return Chord(root, quality, add, bass)
 
     def change_chord(
-            self,
-            chord,
-            root: Union[str, None] = None,
-            quality: Union[str, None] = None,
-            add: Union[str, None] = None,
-            remove: Union[str, None] = None,
-            bass: Union[str, bool, None] = None,
+            self, chord, root=None,
+            quality=None, add=None,
+            remove=None, bass=None,
             inplace=True,
     ):
         """Change a `Chord`'s attributes.

--- a/src/chordparser/editors/keys_editor.py
+++ b/src/chordparser/editors/keys_editor.py
@@ -26,7 +26,7 @@ class KeyEditor:
     def create_key(self, root, mode='major', submode=None):
         """Create a `Key` from a root note, mode and submode.
 
-        The root note must be a valid `Note` notation if type `str`. The submode refers to the different types of minor/aeolian mode, i.e. natural, harmonic and melodic. Hence, other than the 'minor'/'aeolian' mode, the submode must be None.
+        The root note must be a valid `Note` notation if type `str`. The submode refers to the different types of minor/aeolian mode, i.e. natural, harmonic and melodic. Hence, other than the 'minor'/ 'aeolian' mode, the submode must be None.
 
         Parameters
         ----------
@@ -35,7 +35,7 @@ class KeyEditor:
         mode : {'major', 'minor', 'ionian', 'dorian', 'phrygian', 'lydian', 'mixolydian', 'aeolian', 'locrian'}, Optional
             The mode of the `Key`.
         submode: {None, 'natural', 'harmonic', 'melodic'}, Optional
-            The submode of the `Key`. Default 'natural' for the 'minor'/'aeolian' mode and None for the other modes when optional.
+            The submode of the `Key`. Default 'natural' for the 'minor'/ 'aeolian' mode and None for the other modes when optional.
 
         Returns
         -------
@@ -45,9 +45,9 @@ class KeyEditor:
         Raises
         ------
         ModeError
-            If the `mode` is not 'minor'/'aeolian' and the `submode` has been specified.
+            If the `mode` is not 'minor'/ 'aeolian' and the `submode` has been specified.
         SyntaxError
-            If the `mode` is 'minor'/'aeolian' and the `submode` is invalid.
+            If the `mode` is 'minor'/ 'aeolian' and the `submode` is invalid.
 
         Examples
         --------
@@ -95,7 +95,7 @@ class KeyEditor:
     def relative_major(self, key):
         """Change a `Key` to its relative major.
 
-        The `Key`'s `mode` must be 'minor'/'aeolian'.
+        The `Key`'s `mode` must be 'minor'/ 'aeolian'.
 
         Parameters
         ----------
@@ -105,7 +105,7 @@ class KeyEditor:
         Raises
         ------
         ModeError
-            If the `Key` is not 'minor'/'aeolian'.
+            If the `Key` is not 'minor'/ 'aeolian'.
 
         Examples
         --------
@@ -125,7 +125,7 @@ class KeyEditor:
     def relative_minor(self, key, submode='natural'):
         """Change a `Key` to its relative minor.
 
-        The `Key`'s `mode` must be 'major'/'ionian'.
+        The `Key`'s `mode` must be 'major'/ 'ionian'.
 
         Parameters
         ----------
@@ -137,7 +137,7 @@ class KeyEditor:
         Raises
         ------
         ModeError
-            If the `Key` is not 'major'/'ionian'.
+            If the `Key` is not 'major'/ 'ionian'.
         SyntaxError
             If the `submode` is invalid.
 
@@ -164,7 +164,7 @@ class KeyEditor:
     def change_key(self, key, root=None, mode=None, submode=None, inplace=True):
         """Change a `Key`'s `root`, `mode` and/or `submode` attributes.
 
-        The root note must be a valid `Note` notation if type `str`. The submode refers to the different types of 'minor'/'aeolian' mode, i.e. 'natural', 'harmonic' and 'melodic'. Hence, other than the 'minor'/'aeolian' mode, the submode must be None.
+        The root note must be a valid `Note` notation if type `str`. The submode refers to the different types of 'minor'/ 'aeolian' mode, i.e. 'natural', 'harmonic' and 'melodic'. Hence, other than the 'minor'/ 'aeolian' mode, the submode must be None.
 
         Parameters
         ----------
@@ -175,7 +175,7 @@ class KeyEditor:
         mode : {None, 'major', 'minor', 'ionian', 'dorian', 'phrygian', 'lydian', 'mixolydian', 'aeolian', 'locrian'}, Optional
             The `mode` of the `Key` to be changed.
         submode: {None, 'natural', 'harmonic', 'melodic'}, Optional
-            The submode of the `Key` to be changed. Default 'natural' for the 'minor'/'aeolian' mode and None for the other modes when optional.
+            The submode of the `Key` to be changed. Default 'natural' for the 'minor'/ 'aeolian' mode and None for the other modes when optional.
         inplace : boolean, optional
             Selector to change the notation of current `Key` or to return a new `Key`. Default True when optional.
 

--- a/src/chordparser/editors/keys_editor.py
+++ b/src/chordparser/editors/keys_editor.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 from chordparser.editors.notes_editor import NoteEditor
 from chordparser.music.keys import Key
 from chordparser.music.notes import Note
@@ -25,12 +23,7 @@ class KeyEditor:
     _submodes = ('harmonic', 'melodic', 'natural')
     _NE = NoteEditor()
 
-    def create_key(
-            self,
-            root,
-            mode: str = 'major',
-            submode: Union[str, None] = None
-    ):
+    def create_key(self, root, mode='major', submode=None):
         """Create a `Key` from a root note, mode and submode.
 
         The root note must be a valid `Note` notation if type `str`. The submode refers to the different types of minor/aeolian mode, i.e. natural, harmonic and melodic. Hence, other than the 'minor'/'aeolian' mode, the submode must be None.

--- a/src/chordparser/editors/scales_editor.py
+++ b/src/chordparser/editors/scales_editor.py
@@ -55,7 +55,7 @@ class ScaleEditor:
     def change_scale(self, scale, *args, inplace=True, **kwargs):
         """Change a `Scale` based on its `Key`.
 
-        The parameters accepted are the same parameters accepted for changing a `Key`: the `root`, `mode` and `submode`. The `root` must be a valid `Note` notation if type `str`. The `submode` refers to the different types of 'minor'/'aeolian' mode, i.e. 'natural', 'harmonic' and 'melodic'. Hence, other than the 'minor'/'aeolian' `mode`, the `submode` must be None.
+        The parameters accepted are the same parameters accepted for changing a `Key`: the `root`, `mode` and `submode`. The `root` must be a valid `Note` notation if type `str`. The `submode` refers to the different types of 'minor'/ 'aeolian' mode, i.e. 'natural', 'harmonic' and 'melodic'. Hence, other than the 'minor'/ 'aeolian' `mode`, the `submode` must be None.
 
         Parameters
         ----------

--- a/src/chordparser/editors/scales_editor.py
+++ b/src/chordparser/editors/scales_editor.py
@@ -33,7 +33,7 @@ class ScaleEditor:
 
         See Also
         --------
-        chordparser.editors.keys_editor.KeyEditor.create_key : See the necessary parameters for creating a `Key`.
+        chordparser.KeyEditor.create_key : See the necessary parameters for creating a `Key`.
 
         Examples
         --------

--- a/src/chordparser/music/chords.py
+++ b/src/chordparser/music/chords.py
@@ -1,5 +1,3 @@
-from typing import Union, List, Tuple
-
 from chordparser.editors.notes_editor import NoteEditor
 from chordparser.editors.scales_editor import ScaleEditor
 from chordparser.music.keys import Key
@@ -19,7 +17,7 @@ class Chord:
     quality : Quality
         The `Chord` quality.
     add : list of (str, int), Optional
-        List of added notes.
+        List of added notes. The `str` is the accidental and the `int` is the scale degree of each added note.
     bass : Note, Optional
         Bass note.
     string : str, Optional
@@ -57,14 +55,7 @@ class Chord:
     _SE = ScaleEditor()
     _NE = NoteEditor()
 
-    def __init__(
-            self,
-            root: Note,
-            quality: Quality,
-            add: Union[List[Tuple[str, int]], None] = None,
-            bass: Union[Note, None] = None,
-            string: str = None,
-    ):
+    def __init__(self, root, quality, add=None, bass=None, string=None):
         self.root = root
         self.quality = quality
         self.add = add
@@ -188,7 +179,7 @@ class Chord:
         if not self.string:
             self.string = self._notation
 
-    def transpose(self, semitones: int, letter: int):
+    def transpose(self, semitones, letter):
         """Transpose a `Chord` according to semitone and letter intervals.
 
         Parameters
@@ -214,7 +205,7 @@ class Chord:
         self.build()
         return self
 
-    def transpose_simple(self, semitones: int, use_flats=False):
+    def transpose_simple(self, semitones, use_flats=False):
         """Transpose a `Chord` according to semitone intervals.
 
         Parameters

--- a/src/chordparser/music/keys.py
+++ b/src/chordparser/music/keys.py
@@ -13,7 +13,7 @@ class Key:
     mode : {'major', 'minor', 'ionian', 'dorian', 'phrygian', 'lydian', 'mixolydian', 'aeolian', 'locrian'}
         The mode of the `Key`.
     submode : {None, 'natural', 'harmonic', 'melodic'}
-        The submode of the `Key`. If the `mode` is not 'minor'/'aeolian', `submode` is None. Else, `submode` is one of the strings.
+        The submode of the `Key`. If the `mode` is not 'minor'/ 'aeolian', `submode` is None. Else, `submode` is one of the strings.
 
     Attributes
     ----------
@@ -22,7 +22,7 @@ class Key:
     mode : {'major', 'minor', 'ionian', 'dorian', 'phrygian', 'lydian', 'mixolydian', 'aeolian', 'locrian'}
         The mode of the `Key`.
     submode : {None, 'natural', 'harmonic', 'melodic'}
-        The submode of the `Key`. If the `mode` is not 'minor'/'aeolian', `submode` is None. Else, `submode` is one of the strings.
+        The submode of the `Key`. If the `mode` is not 'minor'/ 'aeolian', `submode` is None. Else, `submode` is one of the strings.
 
     """
 

--- a/src/chordparser/music/keys.py
+++ b/src/chordparser/music/keys.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 from chordparser.music.notes import Note
 
 
@@ -28,10 +26,7 @@ class Key:
 
     """
 
-    def __init__(
-            self, root, mode: str,
-            submode: Union[str, None]
-    ):
+    def __init__(self, root, mode, submode):
         self.root = root
         self.mode = mode
         self.submode = submode

--- a/src/chordparser/music/keys.py
+++ b/src/chordparser/music/keys.py
@@ -36,7 +36,7 @@ class Key:
 
         See Also
         --------
-        chordparser.music.notes.Note : For a list of `Note` methods.
+        chordparser.Note : For a list of `Note` methods.
         """
         if attribute in Note.__dict__:
             return getattr(self.root, attribute)

--- a/src/chordparser/music/notes.py
+++ b/src/chordparser/music/notes.py
@@ -127,7 +127,7 @@ class Note:
         """
         return Note._symbol_signs[self.symbol]
 
-    def accidental(self, value: int):
+    def accidental(self, value):
         """Change a `Note`'s accidental by specifying a `value` from -2 to 2.
 
         The range of `values` [-2, 2] correspond to the values a symbol can take, from doubleflat (-2) to doublesharp (2).
@@ -157,7 +157,7 @@ class Note:
         self.symbol = Note._symbols[value]
         return self
 
-    def shift_s(self, value: int):
+    def shift_s(self, value):
         """Shift a `Note`'s accidental.
 
         The `Note`'s `symbol_value()` must be in the range of [-2, 2] after the shift, which corresponds to the values a symbol can take from doubleflat (-2) to doublesharp (2).
@@ -188,7 +188,7 @@ class Note:
         self.symbol = Note._symbols[value]
         return self
 
-    def shift_l(self, value: int):
+    def shift_l(self, value):
         """Shift a `Note`'s letter.
 
         The `value` corresponds to the change in scale degree of the `Note`.
@@ -211,7 +211,7 @@ class Note:
         self.letter = new_letter
         return self
 
-    def transpose(self, semitones: int, letters: int):
+    def transpose(self, semitones, letters):
         """Transpose a `Note` according to semitone and letter intervals.
 
         Parameters
@@ -239,7 +239,7 @@ class Note:
         self.shift_s(shift)
         return self
 
-    def transpose_simple(self, semitones: int, use_flats=False):
+    def transpose_simple(self, semitones, use_flats=False):
         """Transpose a `Note` according to semitone intervals.
 
         Parameters

--- a/src/chordparser/music/scales.py
+++ b/src/chordparser/music/scales.py
@@ -43,7 +43,7 @@ class Scale:
     }
     _NE = NoteEditor()
 
-    def __init__(self, key: Key):
+    def __init__(self, key):
         self.key = key
         self.build()
 
@@ -76,7 +76,7 @@ class Scale:
             notes.append(new_note.transpose(interval, 1))
         return tuple(notes)
 
-    def transpose(self, semitones: int, letter: int):
+    def transpose(self, semitones, letter):
         """Transpose a `Scale` according to semitone and letter intervals.
 
         Parameters
@@ -100,7 +100,7 @@ class Scale:
         self.build()
         return self
 
-    def transpose_simple(self, semitones: int, use_flats=False):
+    def transpose_simple(self, semitones, use_flats=False):
         """Transpose a `Scale` according to semitone intervals.
 
         Parameters


### PR DESCRIPTION
Removed type hints (e.g. bass : Note) to prevent confusion in documentation, since the documentation uses chordparser.Note while the actual module uses chordparser.music.notes.Note. 