### PR TITLE
Enable minor scale in ChordRomanConverter

### DIFF
--- a/src/chordparser/editors/chord_roman_converter.py
+++ b/src/chordparser/editors/chord_roman_converter.py
@@ -83,11 +83,12 @@ class ChordRomanConverter:
                 UserWarning
             )
             chord = self._CE.change_chord(chord, quality="Maj", inplace=False)
+            
         if isinstance(scale_key, Scale):
-            scale_root = scale_key.key.root
+            scale = scale_key
         else:
-            scale_root = scale_key.root
-        scale = self._SE.create_scale(scale_root, "major")
+            scale = self._SE.create_scale(scale_key.root, scale_key.mode)
+
         root = self._get_roman_root(chord, scale)
         quality = self._get_roman_quality(chord)
         inversion = self._get_roman_inversion(chord)

--- a/src/chordparser/editors/chord_roman_converter.py
+++ b/src/chordparser/editors/chord_roman_converter.py
@@ -87,7 +87,7 @@ class ChordRomanConverter:
         if isinstance(scale_key, Scale):
             scale = scale_key
         else:
-            scale = self._SE.create_scale(scale_key.root, scale_key.mode, scale_key.submode)
+            scale = self._SE.create_scale(scale_key)
 
         root = self._get_roman_root(chord, scale)
         quality = self._get_roman_quality(chord)

--- a/src/chordparser/editors/chord_roman_converter.py
+++ b/src/chordparser/editors/chord_roman_converter.py
@@ -87,7 +87,7 @@ class ChordRomanConverter:
         if isinstance(scale_key, Scale):
             scale = scale_key
         else:
-            scale = self._SE.create_scale(scale_key.root, scale_key.mode)
+            scale = self._SE.create_scale(scale_key.root, scale_key.mode, scale_key.submode)
 
         root = self._get_roman_root(chord, scale)
         quality = self._get_roman_quality(chord)


### PR DESCRIPTION
Change the conversion to roman numerals so that it is possible to perform analyses in minor keys.

Related issue: [https://github.com/titus-ong/chordparser/issues/40](url)